### PR TITLE
移除所有文件分隔符的特殊处理,改为os.path.join

### DIFF
--- a/LanguageModel.py
+++ b/LanguageModel.py
@@ -7,33 +7,20 @@
 基于马尔可夫模型的语言模型
 
 """
+import os
 import platform as plat
 
 
 class ModelLanguage(): # 语音模型类
 	def __init__(self, modelpath):
 		self.modelpath = modelpath
-		system_type = plat.system() # 由于不同的系统的文件路径表示不一样，需要进行判断
-		
-		self.slash = ''
-		if(system_type == 'Windows'):
-			self.slash = '\\'
-		elif(system_type == 'Linux'):
-			self.slash = '/'
-		else:
-			print('*[Message] Unknown System\n')
-			self.slash = '/'
-		
-		if(self.slash != self.modelpath[-1]): # 在目录路径末尾增加斜杠
-			self.modelpath = self.modelpath + self.slash
-		
 		pass
 		
 	def LoadModel(self):
 		self.dict_pinyin = self.GetSymbolDict('dict.txt')
-		self.model1 = self.GetLanguageModel(self.modelpath + 'language_model1.txt')
-		self.model2 = self.GetLanguageModel(self.modelpath + 'language_model2.txt')
-		self.pinyin = self.GetPinyin(self.modelpath + 'dic_pinyin.txt')
+		self.model1 = self.GetLanguageModel(os.path.join(self.modelpath, 'language_model1.txt'))
+		self.model2 = self.GetLanguageModel(os.path.join(self.modelpath, 'language_model2.txt'))
+		self.pinyin = self.GetPinyin(os.path.join(self.modelpath, 'dic_pinyin.txt'))
 		model = (self.dict_pinyin, self.model1, self.model2 )
 		return model
 		pass

--- a/LanguageModel2.py
+++ b/LanguageModel2.py
@@ -7,33 +7,20 @@
 基于马尔可夫模型的语言模型
 
 """
+import os
 import platform as plat
 
 
 class ModelLanguage(): # 语音模型类
 	def __init__(self, modelpath):
 		self.modelpath = modelpath
-		system_type = plat.system() # 由于不同的系统的文件路径表示不一样，需要进行判断
-		
-		self.slash = ''
-		if(system_type == 'Windows'):
-			self.slash = '\\'
-		elif(system_type == 'Linux'):
-			self.slash = '/'
-		else:
-			print('*[Message] Unknown System\n')
-			self.slash = '/'
-		
-		if(self.slash != self.modelpath[-1]): # 在目录路径末尾增加斜杠
-			self.modelpath = self.modelpath + self.slash
-		
 		pass
 		
 	def LoadModel(self):
 		self.dict_pinyin = self.GetSymbolDict('dict.txt')
-		self.model1 = self.GetLanguageModel(self.modelpath + 'language_model1.txt')
-		self.model2 = self.GetLanguageModel(self.modelpath + 'language_model2.txt')
-		self.pinyin = self.GetPinyin(self.modelpath + 'dic_pinyin.txt')
+		self.model1 = self.GetLanguageModel(os.path.join(self.modelpath, 'language_model1.txt'))
+		self.model2 = self.GetLanguageModel(os.path.join(self.modelpath, 'language_model2.txt'))
+		self.pinyin = self.GetPinyin(os.path.join(self.modelpath, 'dic_pinyin.txt'))
 		model = (self.dict_pinyin, self.model1, self.model2 )
 		return model
 		pass

--- a/SpeechModel24.py
+++ b/SpeechModel24.py
@@ -39,18 +39,6 @@ class ModelSpeech(): # 语音模型类
 		self._model, self.base_model = self.CreateModel() 
 		
 		self.datapath = datapath
-		self.slash = ''
-		system_type = plat.system() # 由于不同的系统的文件路径表示不一样，需要进行判断
-		if(system_type == 'Windows'):
-			self.slash='\\' # 反斜杠
-		elif(system_type == 'Linux'):
-			self.slash='/' # 正斜杠
-		else:
-			print('*[Message] Unknown System\n')
-			self.slash='/' # 正斜杠
-		if(self.slash != self.datapath[-1]): # 在目录路径末尾增加斜杠
-			self.datapath = self.datapath + self.slash
-	
 		
 	def CreateModel(self):
 		'''
@@ -381,18 +369,15 @@ if(__name__=='__main__'):
 	system_type = plat.system() # 由于不同的系统的文件路径表示不一样，需要进行判断
 	if(system_type == 'Windows'):
 		datapath = 'D:\\语音数据集'
-		modelpath = modelpath + '\\'
 	elif(system_type == 'Linux'):
 		datapath = 'dataset'
-		modelpath = modelpath + '/'
 	else:
 		print('*[Message] Unknown System\n')
 		datapath = 'dataset'
-		modelpath = modelpath + '/'
 	
 	ms = ModelSpeech(datapath)
 	
-	#ms.LoadModel(modelpath + 'm24/speech_model24_e_0_step_411000.model')
+	#ms.LoadModel(os.path.join(modelpath, 'm24', 'speech_model24_e_0_step_411000.model'))
 	ms.TrainModel(datapath, epoch = 50, batch_size = 16, save_step = 500)
 	#ms.TestModel(datapath, str_dataset='test', data_count = 128, out_report = True)
 	#r = ms.RecognizeSpeech_FromFile('E:\\语音数据集\\ST-CMDS-20170001_1-OS\\20170001P00241I0053.wav')

--- a/SpeechModel25.py
+++ b/SpeechModel25.py
@@ -39,17 +39,6 @@ class ModelSpeech(): # 语音模型类
 		self._model, self.base_model = self.CreateModel() 
 		
 		self.datapath = datapath
-		self.slash = ''
-		system_type = plat.system() # 由于不同的系统的文件路径表示不一样，需要进行判断
-		if(system_type == 'Windows'):
-			self.slash='\\' # 反斜杠
-		elif(system_type == 'Linux'):
-			self.slash='/' # 正斜杠
-		else:
-			print('*[Message] Unknown System\n')
-			self.slash='/' # 正斜杠
-		if(self.slash != self.datapath[-1]): # 在目录路径末尾增加斜杠
-			self.datapath = self.datapath + self.slash
 	
 		
 	def CreateModel(self):
@@ -390,18 +379,15 @@ if(__name__=='__main__'):
 	system_type = plat.system() # 由于不同的系统的文件路径表示不一样，需要进行判断
 	if(system_type == 'Windows'):
 		datapath = 'E:\\语音数据集'
-		modelpath = modelpath + '\\'
 	elif(system_type == 'Linux'):
 		datapath = 'dataset'
-		modelpath = modelpath + '/'
 	else:
 		print('*[Message] Unknown System\n')
 		datapath = 'dataset'
-		modelpath = modelpath + '/'
 	
 	ms = ModelSpeech(datapath)
 	
-	#ms.LoadModel(modelpath + 'm25/speech_model25_e_0_step_545500.model')
+	#ms.LoadModel(os.path.join(modelpath, 'm25', 'speech_model25_e_0_step_545500.model'))
 	ms.TrainModel(datapath, epoch = 50, batch_size = 16, save_step = 500)
 	#ms.TestModel(datapath, str_dataset='test', data_count = 128, out_report = True)
 	#r = ms.RecognizeSpeech_FromFile('E:\\语音数据集\\ST-CMDS-20170001_1-OS\\20170001P00241I0053.wav')

--- a/SpeechModel251.py
+++ b/SpeechModel251.py
@@ -43,17 +43,6 @@ class ModelSpeech(): # 语音模型类
 		self._model, self.base_model = self.CreateModel() 
 		
 		self.datapath = datapath
-		self.slash = ''
-		system_type = plat.system() # 由于不同的系统的文件路径表示不一样，需要进行判断
-		if(system_type == 'Windows'):
-			self.slash='\\' # 反斜杠
-		elif(system_type == 'Linux'):
-			self.slash='/' # 正斜杠
-		else:
-			print('*[Message] Unknown System\n')
-			self.slash='/' # 正斜杠
-		if(self.slash != self.datapath[-1]): # 在目录路径末尾增加斜杠
-			self.datapath = self.datapath + self.slash
 	
 		
 	def CreateModel(self):
@@ -407,7 +396,7 @@ if(__name__=='__main__'):
 	
 	
 	datapath =  abspath + ''
-	modelpath =  abspath + 'model_speech'
+	modelpath =  os.path.join(abspath, 'model_speech')
 	
 	
 	if(not os.path.exists(modelpath)): # 判断保存模型的目录是否存在
@@ -416,19 +405,16 @@ if(__name__=='__main__'):
 	system_type = plat.system() # 由于不同的系统的文件路径表示不一样，需要进行判断
 	if(system_type == 'Windows'):
 		datapath = 'E:\\语音数据集'
-		modelpath = modelpath + '\\'
 	elif(system_type == 'Linux'):
-		datapath =  abspath + 'dataset'
-		modelpath = modelpath + '/'
+		datapath =  os.path.join(abspath, 'dataset')
 	else:
 		print('*[Message] Unknown System\n')
 		datapath = 'dataset'
-		modelpath = modelpath + '/'
 	
 	ms = ModelSpeech(datapath)
 	
 	
-	#ms.LoadModel(modelpath + 'm251/speech_model251_e_0_step_100000.model')
+	#ms.LoadModel(os.path.join(modelpath, 'm251', 'speech_model251_e_0_step_100000.model'))
 	ms.TrainModel(datapath, epoch = 50, batch_size = 16, save_step = 500)
 	
 	#t1=time.time()

--- a/SpeechModel251_p.py
+++ b/SpeechModel251_p.py
@@ -43,17 +43,6 @@ class ModelSpeech(): # 语音模型类
 		self._model, self.base_model = self.CreateModel() 
 		
 		self.datapath = datapath
-		self.slash = ''
-		system_type = plat.system() # 由于不同的系统的文件路径表示不一样，需要进行判断
-		if(system_type == 'Windows'):
-			self.slash='\\' # 反斜杠
-		elif(system_type == 'Linux'):
-			self.slash='/' # 正斜杠
-		else:
-			print('*[Message] Unknown System\n')
-			self.slash='/' # 正斜杠
-		if(self.slash != self.datapath[-1]): # 在目录路径末尾增加斜杠
-			self.datapath = self.datapath + self.slash
 	
 		
 	def CreateModel(self):
@@ -395,7 +384,7 @@ if(__name__=='__main__'):
 	
 	
 	datapath =  abspath + ''
-	modelpath =  abspath + 'model_speech'
+	modelpath =  os.path.join(abspath, 'model_speech')
 	
 	
 	if(not os.path.exists(modelpath)): # 判断保存模型的目录是否存在
@@ -404,19 +393,16 @@ if(__name__=='__main__'):
 	system_type = plat.system() # 由于不同的系统的文件路径表示不一样，需要进行判断
 	if(system_type == 'Windows'):
 		datapath = 'E:\\语音数据集'
-		modelpath = modelpath + '\\'
 	elif(system_type == 'Linux'):
-		datapath =  abspath + 'dataset'
-		modelpath = modelpath + '/'
+		datapath =  os.path.join(abspath, 'dataset')
 	else:
 		print('*[Message] Unknown System\n')
 		datapath = 'dataset'
-		modelpath = modelpath + '/'
 	
 	ms = ModelSpeech(datapath)
 	
 	
-	#ms.LoadModel(modelpath + 'm251/speech_model251_e_0_step_98000.model')
+	#ms.LoadModel(os.path.join(modelpath, 'm251', 'speech_model251_e_0_step_98000.model'))
 	ms.TrainModel(datapath, epoch = 50, batch_size = 16, save_step = 500)
 	#ms.TestModel(datapath, str_dataset='test', data_count = 128, out_report = True)
 	#r = ms.RecognizeSpeech_FromFile('E:\\语音数据集\\ST-CMDS-20170001_1-OS\\20170001P00241I0053.wav')

--- a/SpeechModel252.py
+++ b/SpeechModel252.py
@@ -42,17 +42,6 @@ class ModelSpeech(): # 语音模型类
 		self._model, self.base_model = self.CreateModel() 
 		
 		self.datapath = datapath
-		self.slash = ''
-		system_type = plat.system() # 由于不同的系统的文件路径表示不一样，需要进行判断
-		if(system_type == 'Windows'):
-			self.slash='\\' # 反斜杠
-		elif(system_type == 'Linux'):
-			self.slash='/' # 正斜杠
-		else:
-			print('*[Message] Unknown System\n')
-			self.slash='/' # 正斜杠
-		if(self.slash != self.datapath[-1]): # 在目录路径末尾增加斜杠
-			self.datapath = self.datapath + self.slash
 		
 		
 	def CreateModel(self):
@@ -399,7 +388,7 @@ if(__name__=='__main__'):
 	
 	
 	datapath =  abspath + ''
-	modelpath =  abspath + 'model_speech'
+	modelpath =  os.path.join(abspath, 'model_speech')
 	
 	
 	if(not os.path.exists(modelpath)): # 判断保存模型的目录是否存在
@@ -408,19 +397,16 @@ if(__name__=='__main__'):
 	system_type = plat.system() # 由于不同的系统的文件路径表示不一样，需要进行判断
 	if(system_type == 'Windows'):
 		datapath = 'E:\\语音数据集'
-		modelpath = modelpath + '\\'
 	elif(system_type == 'Linux'):
-		datapath =  abspath + 'dataset'
-		modelpath = modelpath + '/'
+		datapath =  os.path.join(abspath, 'dataset')
 	else:
 		print('*[Message] Unknown System\n')
 		datapath = 'dataset'
-		modelpath = modelpath + '/'
 	
 	ms = ModelSpeech(datapath)
 	
 	
-	#ms.LoadModel(modelpath + 'm252\\speech_model252_e_0_step_115500.model')
+	#ms.LoadModel(os.path.join(modelpath, 'm252', 'speech_model252_e_0_step_115500.model'))
 	ms.TrainModel(datapath, epoch = 50, batch_size = 4, save_step = 500)
 	#ms.TestModel(datapath, str_dataset='dev', data_count = 128, out_report = True)
 	#r = ms.RecognizeSpeech_FromFile('E:\\语音数据集\\ST-CMDS-20170001_1-OS\\20170001P00241I0053.wav')

--- a/SpeechModel26.py
+++ b/SpeechModel26.py
@@ -40,17 +40,6 @@ class ModelSpeech(): # 语音模型类
 		self._model, self.base_model = self.CreateModel() 
 		
 		self.datapath = datapath
-		self.slash = ''
-		system_type = plat.system() # 由于不同的系统的文件路径表示不一样，需要进行判断
-		if(system_type == 'Windows'):
-			self.slash='\\' # 反斜杠
-		elif(system_type == 'Linux'):
-			self.slash='/' # 正斜杠
-		else:
-			print('*[Message] Unknown System\n')
-			self.slash='/' # 正斜杠
-		if(self.slash != self.datapath[-1]): # 在目录路径末尾增加斜杠
-			self.datapath = self.datapath + self.slash
 	
 		
 	def CreateModel(self):
@@ -408,18 +397,15 @@ if(__name__=='__main__'):
 	system_type = plat.system() # 由于不同的系统的文件路径表示不一样，需要进行判断
 	if(system_type == 'Windows'):
 		datapath = 'E:\\语音数据集'
-		modelpath = modelpath + '\\'
 	elif(system_type == 'Linux'):
 		datapath = 'dataset'
-		modelpath = modelpath + '/'
 	else:
 		print('*[Message] Unknown System\n')
 		datapath = 'dataset'
-		modelpath = modelpath + '/'
 	
 	ms = ModelSpeech(datapath)
 	
-	#ms.LoadModel(modelpath + 'm26/speech_model26_e_0_step_397000.model')
+	#ms.LoadModel(os.path.join(modelpath, 'm26', 'speech_model26_e_0_step_397000.model'))
 	ms.TrainModel(datapath, epoch = 50, batch_size = 16, save_step = 500)
 	#ms.TestModel(datapath, str_dataset='test', data_count = 128, out_report = True)
 	#r = ms.RecognizeSpeech_FromFile('E:\\语音数据集\\ST-CMDS-20170001_1-OS\\20170001P00241I0053.wav')

--- a/SpeechModel261.py
+++ b/SpeechModel261.py
@@ -44,17 +44,6 @@ class ModelSpeech(): # 语音模型类
 		self._model, self.base_model = self.CreateModel() 
 		
 		self.datapath = datapath
-		self.slash = ''
-		system_type = plat.system() # 由于不同的系统的文件路径表示不一样，需要进行判断
-		if(system_type == 'Windows'):
-			self.slash='\\' # 反斜杠
-		elif(system_type == 'Linux'):
-			self.slash='/' # 正斜杠
-		else:
-			print('*[Message] Unknown System\n')
-			self.slash='/' # 正斜杠
-		if(self.slash != self.datapath[-1]): # 在目录路径末尾增加斜杠
-			self.datapath = self.datapath + self.slash
 	
 		
 	def CreateModel(self):
@@ -421,7 +410,7 @@ if(__name__=='__main__'):
 	
 	
 	datapath =  abspath + ''
-	modelpath =  abspath + 'model_speech'
+	modelpath =  os.path.join(abspath, 'model_speech')
 	
 	
 	if(not os.path.exists(modelpath)): # 判断保存模型的目录是否存在
@@ -430,19 +419,16 @@ if(__name__=='__main__'):
 	system_type = plat.system() # 由于不同的系统的文件路径表示不一样，需要进行判断
 	if(system_type == 'Windows'):
 		datapath = 'E:\\语音数据集'
-		modelpath = modelpath + '\\'
 	elif(system_type == 'Linux'):
-		datapath =  abspath + 'dataset'
-		modelpath = modelpath + '/'
+		datapath =  os.path.join(abspath, 'dataset')
 	else:
 		print('*[Message] Unknown System\n')
 		datapath = 'dataset'
-		modelpath = modelpath + '/'
 	
 	ms = ModelSpeech(datapath)
 	
 	
-	#ms.LoadModel(modelpath + 'm261/speech_model261_e_0_step_100000.model')
+	#ms.LoadModel(os.path.join(modelpath, 'm261', 'speech_model261_e_0_step_100000.model'))
 	#ms.TrainModel(datapath, epoch = 50, batch_size = 16, save_step = 500)
 	
 	#t1=time.time()

--- a/SpeechModel261_p.py
+++ b/SpeechModel261_p.py
@@ -44,18 +44,7 @@ class ModelSpeech(): # 语音模型类
 		self._model, self.base_model = self.CreateModel() 
 		
 		self.datapath = datapath
-		self.slash = ''
-		system_type = plat.system() # 由于不同的系统的文件路径表示不一样，需要进行判断
-		if(system_type == 'Windows'):
-			self.slash='\\' # 反斜杠
-		elif(system_type == 'Linux'):
-			self.slash='/' # 正斜杠
-		else:
-			print('*[Message] Unknown System\n')
-			self.slash='/' # 正斜杠
-		if(self.slash != self.datapath[-1]): # 在目录路径末尾增加斜杠
-			self.datapath = self.datapath + self.slash
-	
+
 		
 	def CreateModel(self):
 		'''
@@ -412,7 +401,7 @@ if(__name__=='__main__'):
 	
 	
 	datapath =  abspath + ''
-	modelpath =  abspath + 'model_speech'
+	modelpath =  os.path.join(abspath, 'model_speech')
 	
 	
 	if(not os.path.exists(modelpath)): # 判断保存模型的目录是否存在
@@ -421,19 +410,16 @@ if(__name__=='__main__'):
 	system_type = plat.system() # 由于不同的系统的文件路径表示不一样，需要进行判断
 	if(system_type == 'Windows'):
 		datapath = 'E:\\语音数据集'
-		modelpath = modelpath + '\\'
 	elif(system_type == 'Linux'):
-		datapath =  abspath + 'dataset'
-		modelpath = modelpath + '/'
+		datapath =  os.path.join(abspath, 'dataset')
 	else:
 		print('*[Message] Unknown System\n')
 		datapath = 'dataset'
-		modelpath = modelpath + '/'
 	
 	ms = ModelSpeech(datapath)
 	
 	
-	#ms.LoadModel(modelpath + 'm261/speech_model261_e_0_step_98000.model')
+	#ms.LoadModel(os.path.join(modelpath, 'm261', 'speech_model261_e_0_step_98000.model'))
 	ms.TrainModel(datapath, epoch = 50, batch_size = 16, save_step = 500)
 	#ms.TestModel(datapath, str_dataset='test', data_count = 128, out_report = True)
 	#r = ms.RecognizeSpeech_FromFile('E:\\语音数据集\\ST-CMDS-20170001_1-OS\\20170001P00241I0053.wav')

--- a/asrserver.py
+++ b/asrserver.py
@@ -8,13 +8,14 @@
 import http.server
 import urllib
 import keras
+import os
 from SpeechModel251 import ModelSpeech
 from LanguageModel import ModelLanguage
 
 datapath = './'
 modelpath = 'model_speech/'
 ms = ModelSpeech(datapath)
-ms.LoadModel(modelpath + 'm251/speech_model251_e_0_step_12000.model')
+ms.LoadModel(os.path.join(modelpath, 'm251', 'speech_model251_e_0_step_12000.model'))
 
 ml = ModelLanguage('model_language')
 ml.LoadModel()

--- a/general_function/file_dict.py
+++ b/general_function/file_dict.py
@@ -3,6 +3,7 @@
 '''
 获取符号字典列表的程序
 '''
+import os
 import platform as plat
 
 def GetSymbolList(datapath):
@@ -10,11 +11,7 @@ def GetSymbolList(datapath):
 	加载拼音符号列表，用于标记符号
 	返回一个列表list类型变量
 	'''
-	if(datapath != ''):
-		if(datapath[-1]!='/' or datapath[-1]!='\\'):
-			datapath = datapath + '/'
-	
-	txt_obj=open(datapath + 'dict.txt','r',encoding='UTF-8') # 打开文件并读入
+	txt_obj=open(os.path.join(datapath, 'dict.txt'),'r',encoding='UTF-8') # 打开文件并读入
 	txt_text=txt_obj.read()
 	txt_lines=txt_text.split('\n') # 文本分割
 	list_symbol=[] # 初始化符号列表
@@ -33,18 +30,8 @@ def GetSymbolList_trash2(datapath):
 	返回一个列表list类型变量
 	'''
 
-	datapath_ = datapath.strip('dataset\\')
-
-	system_type = plat.system()  # 由于不同的系统的文件路径表示不一样，需要进行判断
-	if (system_type == 'Windows'):
-		datapath_+='\\'
-	elif (system_type == 'Linux'):
-		datapath_ += '/'
-	else:
-		print('*[Message] Unknown System\n')
-		datapath_ += '/'  
-	
-	txt_obj=open(datapath_ + 'dict.txt','r',encoding='UTF-8') # 打开文件并读入  
+	datapath_ = datapath.strip('dataset')
+	txt_obj=open(os.path.join(datapath_,  'dict.txt'),'r',encoding='UTF-8') # 打开文件并读入
 	txt_text=txt_obj.read()        
 	txt_lines=txt_text.split('\n') # 文本分割    
 	list_symbol=[] # 初始化符号列表

--- a/readdata24.py
+++ b/readdata24.py
@@ -22,23 +22,8 @@ class DataSpeech():
 			path：数据存放位置根目录
 		'''
 		
-		system_type = plat.system() # 由于不同的系统的文件路径表示不一样，需要进行判断
-		
 		self.datapath = path; # 数据存放位置根目录
-		self.type = type # 数据类型，分为三种：训练集(train)、验证集(dev)、测试集(test)
-		
-		self.slash = ''
-		if(system_type == 'Windows'):
-			self.slash='\\' # 反斜杠
-		elif(system_type == 'Linux'):
-			self.slash='/' # 正斜杠
-		else:
-			print('*[Message] Unknown System\n')
-			self.slash='/' # 正斜杠
-		
-		if(self.slash != self.datapath[-1]): # 在目录路径末尾增加斜杠
-			self.datapath = self.datapath + self.slash
-		
+		self.type = type # 数据类型，分为三种：训练集(train)、验证集(dev)、测试集(test)	
 		
 		self.dic_wavlist_thchs30 = {}
 		self.dic_symbollist_thchs30 = {}
@@ -69,29 +54,29 @@ class DataSpeech():
 		'''
 		# 设定选取哪一项作为要使用的数据集
 		if(self.type=='train'):
-			filename_wavlist_thchs30 = 'thchs30' + self.slash + 'train.wav.lst'
-			filename_wavlist_stcmds = 'st-cmds' + self.slash + 'train.wav.txt'
-			filename_symbollist_thchs30 = 'thchs30' + self.slash + 'train.syllable.txt'
-			filename_symbollist_stcmds = 'st-cmds' + self.slash + 'train.syllable.txt'
+			filename_wavlist_thchs30 = os.path.join('thchs30', 'train.wav.lst')
+			filename_wavlist_stcmds = os.path.join('st-cmds', 'train.wav.txt')
+			filename_symbollist_thchs30 = os.path.join('thchs30', 'train.syllable.txt')
+			filename_symbollist_stcmds = os.path.join('st-cmds', 'train.syllable.txt')
 		elif(self.type=='dev'):
-			filename_wavlist_thchs30 = 'thchs30' + self.slash + 'cv.wav.lst'
-			filename_wavlist_stcmds = 'st-cmds' + self.slash + 'dev.wav.txt'
-			filename_symbollist_thchs30 = 'thchs30' + self.slash + 'cv.syllable.txt'
-			filename_symbollist_stcmds = 'st-cmds' + self.slash + 'dev.syllable.txt'
+			filename_wavlist_thchs30 = os.path.join('thchs30', 'cv.wav.lst')
+			filename_wavlist_stcmds = os.path.join('st-cmds', 'dev.wav.txt')
+			filename_symbollist_thchs30 = os.path.join('thchs30', 'cv.syllable.txt')
+			filename_symbollist_stcmds = os.path.join('st-cmds', 'dev.syllable.txt')
 		elif(self.type=='test'):
-			filename_wavlist_thchs30 = 'thchs30' + self.slash + 'test.wav.lst'
-			filename_wavlist_stcmds = 'st-cmds' + self.slash + 'test.wav.txt'
-			filename_symbollist_thchs30 = 'thchs30' + self.slash + 'test.syllable.txt'
-			filename_symbollist_stcmds = 'st-cmds' + self.slash + 'test.syllable.txt'
+			filename_wavlist_thchs30 = os.path.join('thchs30', 'test.wav.lst')
+			filename_wavlist_stcmds = os.path.join('st-cmds', 'test.wav.txt')
+			filename_symbollist_thchs30 = os.path.join('thchs30', 'test.syllable.txt')
+			filename_symbollist_stcmds = os.path.join('st-cmds', 'test.syllable.txt')
 		else:
 			filename_wavlist = '' # 默认留空
 			filename_symbollist = ''
 		# 读取数据列表，wav文件列表和其对应的符号列表
-		self.dic_wavlist_thchs30,self.list_wavnum_thchs30 = get_wav_list(self.datapath + filename_wavlist_thchs30)
-		self.dic_wavlist_stcmds,self.list_wavnum_stcmds = get_wav_list(self.datapath + filename_wavlist_stcmds)
+		self.dic_wavlist_thchs30,self.list_wavnum_thchs30 = get_wav_list(os.path.join(self.datapath, filename_wavlist_thchs30))
+		self.dic_wavlist_stcmds,self.list_wavnum_stcmds = get_wav_list(os.path.join(self.datapath, filename_wavlist_stcmds))
 		
-		self.dic_symbollist_thchs30,self.list_symbolnum_thchs30 = get_wav_symbol(self.datapath + filename_symbollist_thchs30)
-		self.dic_symbollist_stcmds,self.list_symbolnum_stcmds = get_wav_symbol(self.datapath + filename_symbollist_stcmds)
+		self.dic_symbollist_thchs30,self.list_symbolnum_thchs30 = get_wav_symbol(os.path.join(self.datapath, filename_symbollist_thchs30))
+		self.dic_symbollist_stcmds,self.list_symbolnum_stcmds = get_wav_symbol(os.path.join(self.datapath, filename_symbollist_stcmds))
 		self.DataNum = self.GetDataNum()
 	
 	def GetDataNum(self):
@@ -135,10 +120,7 @@ class DataSpeech():
 			filename = self.dic_wavlist_stcmds[self.list_wavnum_stcmds[(n + yushu - 1)%length]]
 			list_symbol=self.dic_symbollist_stcmds[self.list_symbolnum_stcmds[(n + yushu - 1)%length]]
 		
-		if('Windows' == plat.system()):
-			filename = filename.replace('/','\\') # windows系统下需要执行这一行，对文件路径做特别处理
-		
-		wavsignal,fs=read_wav_data(self.datapath + filename)
+		wavsignal,fs=read_wav_data(os.path.join(self.datapath, filename))
 		
 		# 获取输出特征
 		

--- a/test.py
+++ b/test.py
@@ -6,7 +6,7 @@
 语音模型 + 语言模型
 """
 import platform as plat
-
+import os
 from SpeechModel251 import ModelSpeech
 from LanguageModel2 import ModelLanguage
 from keras import backend as K
@@ -17,19 +17,16 @@ modelpath = 'model_speech'
 system_type = plat.system() # 由于不同的系统的文件路径表示不一样，需要进行判断
 if(system_type == 'Windows'):
 	datapath = 'D:\\语音数据集'
-	modelpath = modelpath + '\\'
 elif(system_type == 'Linux'):
 	datapath = 'dataset'
-	modelpath = modelpath + '/'
 else:
 	print('*[Message] Unknown System\n')
 	datapath = 'dataset'
-	modelpath = modelpath + '/'
 
 ms = ModelSpeech(datapath)
 
-#ms.LoadModel(modelpath + 'm22_2\\0\\speech_model22_e_0_step_257000.model')
-ms.LoadModel(modelpath + 'm251\\speech_model251_e_0_step_12000.model')
+#ms.LoadModel(os.path.join(modelpath, 'm22_2', '0', 'speech_model22_e_0_step_257000.model'))
+ms.LoadModel(os.path.join(modelpath, 'm251', 'speech_model251_e_0_step_12000.model'))
 
 #ms.TestModel(datapath, str_dataset='test', data_count = 64, out_report = True)
 r = ms.RecognizeSpeech_FromFile('D:\\语音数据集\\ST-CMDS-20170001_1-OS\\20170001P00241I0052.wav')

--- a/test_mspeech.py
+++ b/test_mspeech.py
@@ -33,18 +33,15 @@ if(not os.path.exists(modelpath)): # 判断保存模型的目录是否存在
 system_type = plat.system() # 由于不同的系统的文件路径表示不一样，需要进行判断
 if(system_type == 'Windows'):
 	datapath = 'E:\\语音数据集'
-	modelpath = modelpath + '\\'
 elif(system_type == 'Linux'):
 	datapath = 'dataset'
-	modelpath = modelpath + '/'
 else:
 	print('*[Message] Unknown System\n')
 	datapath = 'dataset'
-	modelpath = modelpath + '/'
 
 ms = ModelSpeech(datapath)
 
-ms.LoadModel(modelpath + 'm251/speech_model251_e_0_step_42500.model')
+ms.LoadModel(os.path.join(modelpath, 'm251', 'speech_model251_e_0_step_42500.model'))
 
 ms.TestModel(datapath, str_dataset='test', data_count = 128, out_report = True)
 

--- a/train_mspeech.py
+++ b/train_mspeech.py
@@ -32,18 +32,15 @@ if(not os.path.exists(modelpath)): # 判断保存模型的目录是否存在
 system_type = plat.system() # 由于不同的系统的文件路径表示不一样，需要进行判断
 if(system_type == 'Windows'):
 	datapath = 'E:\\语音数据集'
-	modelpath = modelpath + '\\'
 elif(system_type == 'Linux'):
 	datapath = 'dataset'
-	modelpath = modelpath + '/'
 else:
 	print('*[Message] Unknown System\n')
 	datapath = 'dataset'
-	modelpath = modelpath + '/'
 
 ms = ModelSpeech(datapath)
 
-#ms.LoadModel(modelpath + 'speech_model251_e_0_step_327500.model')
+#ms.LoadModel(os.path.join(modelpath, 'speech_model251_e_0_step_327500.model'))
 ms.TrainModel(datapath, epoch = 50, batch_size = 16, save_step = 500)
 
 


### PR DESCRIPTION
感谢作者提供中文ASR的方案。看了下代码，有非常多处用到了类似下面这样的平台差异化处理代码：

``` python
system_type = plat.system() # 由于不同的系统的文件路径表示不一样，需要进行判断
if(system_type == 'Windows'):
	self.slash='\\' # 反斜杠
elif(system_type == 'Linux'):
	self.slash='/' # 正斜杠
else:
	print('*[Message] Unknown System\n')
	self.slash='/' # 正斜杠
if(self.slash != self.datapath[-1]): # 在目录路径末尾增加斜杠
	self.datapath = self.datapath + self.slash
```

然而这样的差异化代码其实完全可以用 `os.path.join` 或者 `os.sep` 取代。见 `os.path.join` 的定义：

![image](https://user-images.githubusercontent.com/1631405/66146400-48c97080-e63f-11e9-96fa-96a17da650d4.png)

所以提了这个 PR 。注意因为数据集太多，我并没有充分自测。建议作者先 clone 我的版本(`git clone https://github.com/wzpan/ASRT_SpeechRecognition.git`)测试无误后再考虑合并。

FYI，关于代码还有一个建议：

目前 Model 类非常多，但里头的实现大同小异。是不是可以考虑抽出一个 AbstractModel 基类，包含共同的方法。而所有的 Model 都继承自这个基类？